### PR TITLE
add missing funcs for th client

### DIFF
--- a/thematic_client_sdk/data.py
+++ b/thematic_client_sdk/data.py
@@ -5,10 +5,22 @@ from .requester import Requestor
 class Data(Requestor):
 
     def upload_data(self, survey_id, file_location, job_type='newdata'):
-        '''
+        """
         Uploads data and provides an identifier that can be used for checking on the status
         of an upload in progress
-        '''
+
+        Args:
+            survey_id (int): The survey ID
+            file_location (string): Path to the data file
+            job_type (string): one of 'newdata', 'initialdata', 'replacedata', 'replaceinputdata'. 
+                newdata: workflow+append+apply
+                replacedata:no-workflow+replace+apply
+                replaceinputdata: workflow+replace+apply
+                initialdata: workflow+replace+full
+        Returns:
+            (str): upload ID
+        """
+
         url = self.create_url('/survey/{}/upload'.format(survey_id))
         files = {'file': open(file_location, 'rb')}
 
@@ -112,34 +124,6 @@ class Data(Requestor):
 
         return True
 
-    def upload_data(self, survey_id, file_location, job_type):
-        """
-        Upload a data file. 
-
-        Args:
-            survey_id (int): The survey ID
-            file_location (string): Path to the data file
-            job_type (string): one of 'newdata', 'initialdata', 'replacedata', 'replaceinputdata'. 
-                newdata: workflow+append+apply
-                replacedata:no-workflow+replace+apply
-                replaceinputdata: workflow+replace+apply
-                initialdata: workflow+replace+full
-        Returns:
-            (str): upload ID
-        """
-        url = self.create_url(f"/survey/{survey_id}/upload")
-        files = {"file": open(file_location, "rb")}
-        params = {"jobType": job_type}
-
-        response = requests.post(url, headers={"Authorization": "bearer " + self.access_token}, files=files, data=params)
-        if response.status_code != 200:
-            raise Exception("Could not upload data: " + str(response.text))
-
-        resp = response.json()
-        if not resp or "data" not in resp or "upload_id" not in resp["data"]:
-            raise Exception(f"upload data got a response that did not have the expected format: {resp}")
-        return resp["data"]["upload_id"]
-
 
     def download_themes(self, download_location, survey_id, result_id=None):
         '''
@@ -241,73 +225,4 @@ class Data(Requestor):
         return resp["data"]["upload_id"]
 
 
-    def get_upload_status(self, survey_id, upload_id):
-        """
-        get status of an upload job
-        """
-        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/status")
-        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token})
-        data = response.json()["data"]
-        # print(response.json())
-        return data.get("status", None), data.get("result_full_id", None)
-
-    def get_upload_info(self, survey_id, upload_id):
-        """
-        get info about an upload job
-        """
-        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}")
-        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token})
-        return response.json()["data"]
-
-
-    def download_log(self, survey_id, download_location, upload_id):
-        """
-        get log for an upload job
-        """
-        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/logs")
-        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
-
-        if response.status_code != 200:
-            raise Exception("Could not retrieve log: " + str(response.text))
-
-        with open(download_location, "wb") as f_handle:
-            for chunk in response.iter_content(chunk_size=1024):
-                if chunk:  # filter out keep-alive new chunks
-                    f_handle.write(chunk)
-
-        return True
-
-    def download_user_log(self, survey_id, download_location, upload_id):
-        """
-        get user log for an upload job
-        """
-        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/user_logs")
-        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
-
-        if response.status_code != 200:
-            raise Exception("Could not retrieve user log: " + str(response.text))
-
-        with open(download_location, "wb") as f_handle:
-            for chunk in response.iter_content(chunk_size=1024):
-                if chunk:  # filter out keep-alive new chunks
-                    f_handle.write(chunk)
-
-        return True
-
-    def download_upload(self, survey_id, download_location, upload_id, unconverted):
-        """
-        download upload
-        """
-        leaf = "input" if unconverted else "converted_input"
-        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/{leaf}")
-        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
-        if response.status_code != 200:
-            raise Exception("Could not retrieve upload: " + str(response.text))
-
-        with open(download_location, "wb") as f_handle:
-            for chunk in response.iter_content(chunk_size=1024):
-                if chunk:  # filter out keep-alive new chunks
-                    f_handle.write(chunk)
-
-        return True
 

--- a/thematic_client_sdk/data.py
+++ b/thematic_client_sdk/data.py
@@ -112,6 +112,35 @@ class Data(Requestor):
 
         return True
 
+    def upload_data(self, survey_id, file_location, job_type):
+        """
+        Upload a data file. 
+
+        Args:
+            survey_id (int): The survey ID
+            file_location (string): Path to the data file
+            job_type (string): one of 'newdata', 'initialdata', 'replacedata', 'replaceinputdata'. 
+                newdata: workflow+append+apply
+                replacedata:no-workflow+replace+apply
+                replaceinputdata: workflow+replace+apply
+                initialdata: workflow+replace+full
+        Returns:
+            (str): upload ID
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload")
+        files = {"file": open(file_location, "rb")}
+        params = {"jobType": job_type}
+
+        response = requests.post(url, headers={"Authorization": "bearer " + self.access_token}, files=files, data=params)
+        if response.status_code != 200:
+            raise Exception("Could not upload data: " + str(response.text))
+
+        resp = response.json()
+        if not resp or "data" not in resp or "upload_id" not in resp["data"]:
+            raise Exception(f"upload data got a response that did not have the expected format: {resp}")
+        return resp["data"]["upload_id"]
+
+
     def download_themes(self, download_location, survey_id, result_id=None):
         '''
         If result_id is not provided then the latest results will be downloaded
@@ -135,6 +164,24 @@ class Data(Requestor):
 
         return True
 
+    def upload_themes(self, survey_id, file_location):
+        """
+        Upload a themes file
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload_themes")
+        files = {"file": open(file_location, "rb")}
+
+        response = requests.post(url, headers={"Authorization": "bearer " + self.access_token}, files=files)
+        if response.status_code != 200:
+            raise Exception("Could not upload themes: " + str(response.text))
+
+        resp = response.json()
+        if not resp or "data" not in resp or "upload_id" not in resp["data"]:
+            raise Exception(f"upload themes got a response that did not have the expected format: {resp}")
+        return resp["data"]["upload_id"]
+
+
+
     def download_db(self, download_location, survey_id, result_id=None):
         '''
         If result_id is not provided then the latest results will be downloaded
@@ -157,3 +204,110 @@ class Data(Requestor):
                     f_handle.write(chunk)
 
         return True
+
+    def download_concepts(self, download_location, survey_id, result_id=None):
+        """
+        If result_id is not provided then the latest results will be downloaded
+        """
+        url = self.create_url("/survey/{}/data_concepts".format(survey_id))
+        if result_id:
+            url = self.create_url("/survey/{}/result/{}/data_concepts".format(survey_id, result_id))
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
+
+        if response.status_code != 200:
+            raise Exception("Could not retrieve concepts: " + str(response.text))
+
+        with open(download_location, "wb") as f_handle:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f_handle.write(chunk)
+
+        return True
+
+    def upload_concepts(self, survey_id, file_location):
+        """
+        uploads a concept file
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload_concepts")
+        files = {"file": open(file_location, "rb")}
+
+        response = requests.post(url, headers={"Authorization": "bearer " + self.access_token}, files=files)
+        if response.status_code != 200:
+            raise Exception("Could not upload concepts: " + str(response.text))
+
+        resp = response.json()
+        if not resp or "data" not in resp or "upload_id" not in resp["data"]:
+            raise Exception(f"upload concepts got a response that did not have the expected format: {resp}")
+        return resp["data"]["upload_id"]
+
+
+    def get_upload_status(self, survey_id, upload_id):
+        """
+        get status of an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/status")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token})
+        data = response.json()["data"]
+        # print(response.json())
+        return data.get("status", None), data.get("result_full_id", None)
+
+    def get_upload_info(self, survey_id, upload_id):
+        """
+        get info about an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token})
+        return response.json()["data"]
+
+
+    def download_log(self, survey_id, download_location, upload_id):
+        """
+        get log for an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/logs")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
+
+        if response.status_code != 200:
+            raise Exception("Could not retrieve log: " + str(response.text))
+
+        with open(download_location, "wb") as f_handle:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f_handle.write(chunk)
+
+        return True
+
+    def download_user_log(self, survey_id, download_location, upload_id):
+        """
+        get user log for an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/user_logs")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
+
+        if response.status_code != 200:
+            raise Exception("Could not retrieve user log: " + str(response.text))
+
+        with open(download_location, "wb") as f_handle:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f_handle.write(chunk)
+
+        return True
+
+    def download_upload(self, survey_id, download_location, upload_id, unconverted):
+        """
+        download upload
+        """
+        leaf = "input" if unconverted else "converted_input"
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/{leaf}")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
+        if response.status_code != 200:
+            raise Exception("Could not retrieve upload: " + str(response.text))
+
+        with open(download_location, "wb") as f_handle:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f_handle.write(chunk)
+
+        return True
+

--- a/thematic_client_sdk/surveys.py
+++ b/thematic_client_sdk/surveys.py
@@ -96,3 +96,42 @@ class Surveys(Requestor):
             if response.status_code != 200:
                 raise Exception('Could not retrieve survey workflow: '+str(response.text))
 
+    def get_params(self, survey_id, result_id=None):
+        '''
+        Get parameters of mauithemes job 
+
+        Args:
+            survey_id (str): the survey id
+            result_id (str): parameters of which result. Gets parameters of latest result if result is None
+
+        Returns:
+            (Dict[str]): Dictionary containing mauithemes parameters
+        '''
+        url = self.create_url(f"/survey/{survey_id}/data_parameters")
+        if result_id:
+            url = self.create_url(f"/survey/{survey_id}/result/{result_id}/data_parameters")
+
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token})
+
+        if response.status_code != 200:
+            raise Exception(f"Could not retrieve params: {response.text}")
+
+        return response.json()["data"]
+
+
+    def put_params(self, survey_id, params):
+        '''
+        Change parameters of mauithemes job 
+
+        Args:
+            survey_id (str): the survey id
+            params (Dict[str]): parameters to set
+        '''
+        url = self.create_url(f'/survey/{survey_id}/themes/parameters/apply')
+        payload = {
+            "parameters": params,
+        }
+        response = requests.post(
+            url, headers={'Authorization': 'bearer ' + self.access_token}, json=payload)
+        if response.status_code != 200:
+            raise Exception(f'Could not upload params: {response.text}')

--- a/thematic_client_sdk/upload_jobs.py
+++ b/thematic_client_sdk/upload_jobs.py
@@ -37,4 +37,67 @@ class UploadJobs(Requestor):
             f.write(response.text)
 
 
+    def get_converted_input(self,survey_id,upload_id,output_filename):
+        url = self.create_url('/survey/{}/upload/{}/converted_input'.format(survey_id,upload_id))
+        response = requests.get(
+            url, headers={'Authorization': 'bearer ' + self.access_token})
+        if response.status_code != 200:
+            raise Exception(
+                'Could not retrieve input: '+str(response.text))
+        with open(output_filename,'w') as f:
+            f.write(response.text)
+
+
+    def get_upload_status(self, survey_id, upload_id):
+        """
+        get status of an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/status")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token})
+        data = response.json()["data"]
+        # print(response.json())
+        return data.get("status", None), data.get("result_full_id", None)
+
+    def get_upload_info(self, survey_id, upload_id):
+        """
+        get info about an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token})
+        return response.json()["data"]
+
+
+    def download_log(self, survey_id, download_location, upload_id):
+        """
+        get log for an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/logs")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
+
+        if response.status_code != 200:
+            raise Exception("Could not retrieve log: " + str(response.text))
+
+        with open(download_location, "wb") as f_handle:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f_handle.write(chunk)
+
+        return True
+
+    def download_user_log(self, survey_id, download_location, upload_id):
+        """
+        get user log for an upload job
+        """
+        url = self.create_url(f"/survey/{survey_id}/upload/{upload_id}/user_logs")
+        response = requests.get(url, headers={"Authorization": "bearer " + self.access_token}, stream=True)
+
+        if response.status_code != 200:
+            raise Exception("Could not retrieve user log: " + str(response.text))
+
+        with open(download_location, "wb") as f_handle:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:  # filter out keep-alive new chunks
+                    f_handle.write(chunk)
+
+        return True
 

--- a/thematic_client_sdk/upload_jobs.py
+++ b/thematic_client_sdk/upload_jobs.py
@@ -48,7 +48,7 @@ class UploadJobs(Requestor):
             f.write(response.text)
 
 
-    def get_upload_status(self, survey_id, upload_id):
+    def get_status(self, survey_id, upload_id):
         """
         get status of an upload job
         """
@@ -58,7 +58,7 @@ class UploadJobs(Requestor):
         # print(response.json())
         return data.get("status", None), data.get("result_full_id", None)
 
-    def get_upload_info(self, survey_id, upload_id):
+    def get_info(self, survey_id, upload_id):
         """
         get info about an upload job
         """
@@ -67,7 +67,7 @@ class UploadJobs(Requestor):
         return response.json()["data"]
 
 
-    def download_log(self, survey_id, download_location, upload_id):
+    def get_log(self, survey_id, download_location, upload_id):
         """
         get log for an upload job
         """
@@ -84,7 +84,7 @@ class UploadJobs(Requestor):
 
         return True
 
-    def download_user_log(self, survey_id, download_location, upload_id):
+    def get_user_log(self, survey_id, download_location, upload_id):
         """
         get user log for an upload job
         """


### PR DESCRIPTION
this pr adds funcs to the client sdk that are needed for the th client. They are currently injected into the sdk at runtime:

```
from thematic_client_sdk.data import Data
Data.download_concepts = download_concepts
Data.upload_concepts = upload_concepts
...

```
Which is a bit messy. Some of these may be useful for others too

I do think there are some admin only restrictions on some of these funcs but not sure which ones. If we merge this PR, prob best to properly document that?