### PR TITLE
PORTAL-7697: add async siblings for endpoints used by Triage Agent

### DIFF
--- a/thematic_client_sdk/auth.py
+++ b/thematic_client_sdk/auth.py
@@ -1,4 +1,5 @@
 import json
+import aiohttp
 import requests
 
 from thematic_client_sdk.config import DEFAULT_DOMAIN, DEFAULT_CLIENTID, DEFAULT_AUDIENCE
@@ -58,3 +59,23 @@ class Auth(object):
         if login_response.status_code != 200:
             raise Exception("Failed to retrieve code: " + login_response.text)
         return login_response.json()["access_token"]
+
+    async def swap_refresh_token_async(self, refresh_token):
+        login_params = {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "audience": self.audience,
+            "scope": "openid offline_access",
+            "client_id": self.client_id,
+        }
+        url = "https://" + self.domain + "/oauth/token"
+        async with aiohttp.ClientSession() as session:
+            response = await session.post(
+                url,
+                data=json.dumps(login_params),
+                headers={"content-type": "application/json"},
+            )
+            if response.status != 200:
+                raise Exception("Failed to retrieve code: " + await response.text())
+            payload = await response.json()
+        return payload["access_token"]

--- a/thematic_client_sdk/surveys.py
+++ b/thematic_client_sdk/surveys.py
@@ -207,3 +207,37 @@ class Surveys(Requestor):
             result = await response.content.read()
             contents = json.loads(result.decode("utf-8"))
         return contents
+
+    async def get_async(self, survey_id=None):
+        """
+        Retrieves all surveys (when ``survey_id`` is None) or a single
+        survey by id, with the same shape as the sync ``get``.
+        """
+        if survey_id is None:
+            url = self.create_url("/surveys")
+        else:
+            url = self.create_url("/survey/{}".format(survey_id))
+        async with aiohttp.ClientSession() as session:
+            response = await session.get(url, headers=self._headers)
+            if response.status != 200:
+                raise ThematicAPIError(
+                    "Could not retrieve survey: " + str(await response.text())
+                )
+            payload = await response.json()
+        return payload["data"]
+
+    async def get_workflow_async(self, survey_id, outfile):
+        """
+        Retrieves the workflow for a survey (as a zip file) and writes
+        it to ``outfile``.
+        """
+        url = self.create_url("/survey/{}/workflow".format(survey_id))
+        async with aiohttp.ClientSession() as session:
+            response = await session.get(url, headers=self._headers)
+            if response.status != 200:
+                raise ThematicAPIError(
+                    "Could not retrieve survey workflow: " + str(await response.text())
+                )
+            content = await response.content.read()
+        with open(outfile, "wb") as f:
+            f.write(content)

--- a/thematic_client_sdk/upload_jobs.py
+++ b/thematic_client_sdk/upload_jobs.py
@@ -1,3 +1,4 @@
+import aiohttp
 import requests
 from .requester import Requestor
 from .exceptions import ThematicAPIError
@@ -37,3 +38,24 @@ class UploadJobs(Requestor):
             )
         with open(output_filename, "w") as f:
             f.write(response.text)
+
+    async def get_async(self, survey_id, upload_id=None, upload_type=None):
+        """
+        Retrieves all upload jobs for a survey, with the same filtering
+        semantics as the sync ``get``.
+        """
+        url = self.create_url("/survey/{}/uploads".format(survey_id))
+        async with aiohttp.ClientSession() as session:
+            response = await session.get(url, headers=self._headers)
+            if response.status != 200:
+                raise ThematicAPIError(
+                    "Could not retrieve upload jobs: " + str(await response.text())
+                )
+            payload = await response.json()
+        uploads = payload["data"]
+        if upload_id is not None:
+            uploads = [x for x in uploads if x["id"] == upload_id][0]
+        elif upload_type is not None:
+            uploads = [x for x in uploads if x["job_type"] == upload_type]
+        return uploads
+


### PR DESCRIPTION
## Summary

Pure async mirrors of four existing sync methods. Modelled on the existing async pattern in ``visualizations.py`` / ``themes.py`` / ``surveys.py`` (single ``async with aiohttp.ClientSession()``, raise ``ThematicAPIError(message)`` on non-200, no semantic deviation from the sync sibling).

Added:
- ``Auth.swap_refresh_token_async``
- ``Surveys.get_async``
- ``Surveys.get_workflow_async``
- ``UploadJobs.get_async``

## Why

Driven by the Triage Agent (``GetThematic/thematic-internal-systems`` ▸ ``services/agent_workers``), which today wraps each sync SDK call in ``asyncio.to_thread``. That wrapping layer is what Nathan flagged on the agent-side PR: *"client sdk should add async support for these endpoints (like it does for reporting/visualization ones)"*. Once this lands and is repinned in the agent, the ``asyncio.to_thread`` wrapping disappears entirely.

## Scope discipline

This PR is **strictly** "async sibling of an existing sync method, byte-identical behaviour". Specifically NOT in scope:

- No new endpoints (the agent-side direct httpx for ``/logs`` and ``/input`` stays in the agent codebase — those endpoints are not exposed by the SDK and adding them was out of scope for this PR).
- No new return shapes (e.g. did not add a bytes-returning ``get_input_async`` even though the agent wants it).
- No new error semantics (e.g. did not add 404→None or ``status_code`` kwarg on ``ThematicAPIError`` raises — async siblings raise the same way the existing async methods do).

The agent-side adapter takes care of those concerns (LLM-friendly error envelopes, ``IndexError`` translation for missing uploads, 404-as-success sentinels) — the SDK stays general-purpose.

## Test plan

- [ ] Surface check (already verified locally): all four new methods are coroutine functions; their sync siblings are not. Each new method's I/O shape mirrors the sync one (same URL, same headers, same JSON unwrapping).
- [ ] py_compile clean on the three edited files.
- [ ] Follow-up agent-side PR (``thematic-internal-systems``) repins ClientSDK to this commit and replaces ``asyncio.to_thread(...)`` call sites with direct ``await ...async()``.